### PR TITLE
126 fix add semantic UI styling

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,9 +5,11 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TaskMates</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic.min.css">
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.5.0/dist/semantic.min.js"></script>
   </body>
 </html>

--- a/client/src/pages/Signup.tsx
+++ b/client/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent, type ChangeEvent } from "react";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 
 import { useMutation } from "@apollo/client";
 


### PR DESCRIPTION
## Fixed error that was breaking the page by commenting out unused link import
![fix semantic ui styling_1_commented out unused link causing error](https://github.com/user-attachments/assets/e05d77f1-041d-4a19-b957-a17b6eeafdb6)

## Fixed semantic UI display by adding CDN CSS and JS script links to HTML
![fix semantic ui styling_2_added cdn css link to html](https://github.com/user-attachments/assets/eda6f564-9d5b-4178-96eb-76c0e4de560a)

![fix semantic ui styling_3_added cdn js script link to html](https://github.com/user-attachments/assets/12262d4b-20ba-4f0b-bf9f-13da03b91828)

## Dev view results

### Before
![fix semantic ui styling_4_dev view before links applied_tasks page](https://github.com/user-attachments/assets/dc48473b-d653-4ac0-b5b0-68a84bd411ca)

![fix semantic ui styling_5_dev view before links applied_signup page](https://github.com/user-attachments/assets/915c786a-fda9-4bac-a926-4b5bf0b8d077)

### After
![fix semantic ui styling_6_dev view after links applied_tasks page](https://github.com/user-attachments/assets/25d42b43-691b-4ec7-8de8-9fcf3203a828)

![fix semantic ui styling_7_dev view after links applied_sign up page_mobile view](https://github.com/user-attachments/assets/61b57181-c389-46ec-bc60-84f4a981a05d)

![fix semantic ui styling_8_dev view after links applied_sign up page_wide screen view](https://github.com/user-attachments/assets/7d334327-4a29-4317-a976-239fc0b349d2)

## To Do:
- [ ] Widen the input fields on the signup form in mobile view


