### PR TITLE
147 feature add dark mode toggle switch to footer

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,3 +40,66 @@
 .read-the-docs {
   color: #888;
 }
+
+/* Default light mode */
+body.light-mode {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+/* Dark mode */
+body.dark-mode {
+  background-color: #1b1c1d; /* Semantic UI default dark color */
+  color: #ffffff;
+}
+
+/* Semantic UI Inverted Segment for Footer */
+.ui.inverted.segment {
+  background-color: #1b1c1d !important; /* Dark footer */
+  color: #ffffff !important; /* White text for dark footer */
+}
+
+.ui.toggle.checkbox label {
+  color: #ffffff !important; /* Ensure the label remains visible */
+}
+/* Light mode footer */
+body.light-mode .ui.inverted.segment {
+  background-color: #ffffff !important; /* Light background for footer */
+  color: #000000 !important; /* Dark text for light mode */
+}
+
+/* Dark mode footer */
+body.dark-mode .ui.inverted.segment {
+  background-color: #1b1c1d !important; /* Default dark background for footer */
+  color: #ffffff !important; /* Light text for dark mode */
+}
+
+/* Invert color for moon outline icon in dark mode */
+body.dark-mode .moon.icon {
+  filter: invert(1); /* Invert the colors */
+}
+body.dark-mode label {
+  color: #ffffff !important; /* White label for dark mode */
+}
+
+body.dark-mode .tasks.icon {
+  color: #ffffff !important; /* White icon for dark mode */
+}
+/* Light mode link colors */
+body.dark-mode .ui.menu {
+  background-color: #000000;
+}
+
+/* Dark mode link colors */
+body.light-mode .ui.menu {
+  background-color: #ffffff;
+}
+
+body.dark-mode a {
+  color: #ffffff !important; /* White links for dark mode */
+}
+
+/* Light mode - sun icon color */
+body.light-mode .sun.icon {
+  color: #000000; /* Black for sun icon in light mode */
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import { Outlet } from "react-router-dom";
 import { setContext } from "@apollo/client/link/context";
 import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
 const httpLink = createHttpLink({
   uri: "/graphql",
 });
@@ -33,6 +34,7 @@ function App() {
       <div>
         <Navbar />
         <Outlet />
+        <Footer />
       </div>
     </ApolloProvider>
   );

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,0 +1,18 @@
+import React, { useState, useEffect } from "react";
+import { Icon } from "semantic-ui-react";
+
+const Footer: React.FC = () => {
+  const [isDarkMode, setIsDarkMode] = useState<boolean>(
+    () => localStorage.getItem("theme") === "dark"
+  );
+
+  useEffect(() => {
+    // Apply theme class to body
+    document.body.className = isDarkMode ? "dark-mode" : "light-mode";
+    localStorage.setItem("theme", isDarkMode ? "dark" : "light");
+  }, [isDarkMode]);
+
+  const handleThemeToggle = () => {
+    setIsDarkMode(!isDarkMode);
+  };
+

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -16,3 +16,43 @@ const Footer: React.FC = () => {
     setIsDarkMode(!isDarkMode);
   };
 
+  return (
+    <div
+      className="ui inverted segment"
+      style={{
+        backgroundColor: isDarkMode ? "#1b1c1d" : "#f9f9f9",
+        color: isDarkMode ? "#ffffff" : "#000000",
+      }}
+    >
+      <div className="ui container center aligned">
+        <p>
+          &copy; {new Date().getFullYear()} Task Mates. All Rights Reserved.
+        </p>
+        <div className="ui toggle checkbox" style={{ marginTop: "1rem" }}>
+          <input
+            type="checkbox"
+            checked={isDarkMode}
+            onChange={handleThemeToggle}
+            id="theme-toggle"
+          />
+          <label
+            htmlFor="theme-toggle"
+            style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+          >
+            {isDarkMode ? (
+              <>
+                <Icon name="moon outline" />
+              </>
+            ) : (
+              <>
+                <Icon name="sun" />
+              </>
+            )}
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Footer;


### PR DESCRIPTION

<img width="1255" alt="Screenshot 2024-11-18 at 4 20 05 PM" src="https://github.com/user-attachments/assets/ef07f479-0fc4-4a9d-a520-276a9eafd4f6">
<img width="1238" alt="Screenshot 2024-11-18 at 4 20 16 PM" src="https://github.com/user-attachments/assets/a325e3b9-c5fc-401d-bbf0-4649361b877d">


Created Footer component with theme toggle

![Footer code](https://github.com/user-attachments/assets/4fc92544-43a9-4697-b27a-6c5a2406a9a0)

Added Footer component to App.tsx

![app footer](https://github.com/user-attachments/assets/71ba1a44-bbb3-48f1-b775-03ef379c50c6)

Added stylings to handle dark mode

![dark mode css](https://github.com/user-attachments/assets/cd9c194b-11ad-47e6-b784-c7dfd54efa85)
