### PR TITLE
fix nav logout to remove token from local storage

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import auth from '../utils/auth';
 
 const Navbar: React.FC = () => {
   const navigate = useNavigate();
 
   const handleLogout = () => {
     // Add logic to log out user
+    auth.logout();
 
     // Show a message or notification (optional)
     alert("Logged out successfully!");
 
     // Redirect to the login page
-    navigate("/login");
+    navigate("/");
   };
 
   return (


### PR DESCRIPTION
## Added auth.logout function to handleLogout button on the nav to remove the token from local storage. 
![fix handleLogout on nav_5_logic added to remove token from local storage](https://github.com/user-attachments/assets/da8ec234-7b24-4239-93f6-b06ebe62aee7)

## Dev results
### Before
![fix handleLogout on nav_1_token stored before logout](https://github.com/user-attachments/assets/310a1a8f-bb3f-425f-8c89-f1418b63c3d5)

![fix handleLogout on nav_2_token persists after logout button is clicked](https://github.com/user-attachments/assets/4db7a9a4-6df0-4062-adcb-679b6c034423)

![fix handleLogout on nav_3_token persists after logout button is clicked2](https://github.com/user-attachments/assets/64ccd189-4520-4ee9-83a8-74ae5a268625)

### After
![fix handleLogout on nav_4_token removed from local storage](https://github.com/user-attachments/assets/dcefee72-c340-445f-be70-d27e67122a43)


